### PR TITLE
make search observable and dispose for new queries before resolution

### DIFF
--- a/cyclejs-solution/README.md
+++ b/cyclejs-solution/README.md
@@ -2,6 +2,8 @@
 
 This branch contains a Cycle.js solution that reuses most of the components defined for the redux apps, but uses RxJS for much simpler code. All effects in our system are also constrained to driver definitions, so we can be sure that all requests for fetching data come in through the input stream of our fetch driver and all history actions go through the history driver.
 
+This also accomplishes the bonus objective of cancelling search requests by using an Observable for the search call, and `flatMapLatest` to only use the newest non-resolved query.
+
 ## To run
 ```sh
 npm install

--- a/cyclejs-solution/api/index.js
+++ b/cyclejs-solution/api/index.js
@@ -1,7 +1,9 @@
+import { Observable } from 'rx';
+
 import friends from './friends';
 
 // mock api search
-export default function search(query = '', callback) {
+export default function search(query = '') {
   const results = friends.filter(friend => {
     let keep = false;
 
@@ -16,6 +18,18 @@ export default function search(query = '', callback) {
     return keep;
   });
 
-  // setting a more realistic (random) timeout
-  setTimeout(() => callback(results), Math.ceil(Math.random() * 250));
+  // use an observable for our search API so that it's actually cancellable when we dispose of our subscription
+  return Observable.create(observer => {
+    const timeout = setTimeout(() => {
+      console.log(`RESOLVING search ${timeout}`);
+      observer.onNext(results)
+    }, Math.ceil(100 + Math.random() * 250)); // make delay longer to make cancellation more obvious
+
+    console.log(`STARTING search ${timeout}`);
+
+    return () => {
+      console.log(`DISPOSING search ${timeout}`);
+      clearTimeout(timeout)
+    };
+  });
 }

--- a/cyclejs-solution/drivers/fetch.js
+++ b/cyclejs-solution/drivers/fetch.js
@@ -1,15 +1,8 @@
-import { ReplaySubject } from 'rx';
-
 import search from '../api';
 
 export default function fetchDriver(query$) {
-  const friends$ = new ReplaySubject(1);
-
-  query$.subscribe(query => {
-    search(query, friends => {
-      friends$.onNext(friends);
-    });
-  });
-
-  return friends$
+  // for each query item, create a new observable to pass downstream
+  // our search observable will be active until the next query comes in,
+  // when we will unsubscribe and dispose of the previous search observable
+  return query$.flatMapLatest(x => search(x));
 }


### PR DESCRIPTION
This addresses the bonus challenge of cancelling search calls whenever a new query comes in. You can verify that the proper steps are called by looking at the console output, where disposals will show and resolutions will never fire for a given timeout id when query inputs are put in rapidly.

I'm kind of confused about the redux-saga solution though, since [the search call there uses a promise](https://github.com/DerekCuevas/friend-list/blob/8ea37d600e9aae24c075c234d1400672faccf27c/redux-saga-solution/api/index.js#L20-L22), and should resolve no matter what. I guess whether or not that data gets used is what is being controlled in this solution?
